### PR TITLE
Expose sleep mode as a function

### DIFF
--- a/components/sx127x/sx127x.cpp
+++ b/components/sx127x/sx127x.cpp
@@ -342,6 +342,7 @@ void SX127x::set_mode_tx() {
 }
 
 void SX127x::set_mode_standby() { this->set_mode_(MODE_STDBY); }
+void SX127x::set_mode_sleep() { this->set_mode_(MODE_SLEEP); }
 
 void SX127x::dump_config() {
   ESP_LOGCONFIG(TAG, "SX127x:");

--- a/components/sx127x/sx127x.h
+++ b/components/sx127x/sx127x.h
@@ -51,8 +51,9 @@ class SX127x : public Component,
   void set_dio0_pin(InternalGPIOPin *dio0_pin) { this->dio0_pin_ = dio0_pin; }
   void set_frequency(uint32_t frequency) { this->frequency_ = frequency; }
   void set_mode_rx();
-  void set_mode_standby();
   void set_mode_tx();
+  void set_mode_standby();
+  void set_mode_sleep();
   void set_modulation(uint8_t modulation) { this->modulation_ = modulation; }
   void set_pa_pin(uint8_t pin) { this->pa_pin_ = pin; }
   void set_pa_power(uint8_t power) { this->pa_power_ = power; }


### PR DESCRIPTION
Just exposing a public function to turn off (sleep) the LoRA module.

![image](https://github.com/user-attachments/assets/bc7e0ff3-24ec-457b-b015-641df1c9d46f)


```yaml
lambda: "id(sx1278_radio).set_mode_sleep();"
```