### PR TITLE
Make on_packet a pure virtual function

### DIFF
--- a/components/sx127x/sx127x.h
+++ b/components/sx127x/sx127x.h
@@ -36,7 +36,7 @@ enum SX127xBw : uint8_t {
 
 class SX127xListener {
  public:
-  virtual void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr);
+  virtual void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) = 0;
 };
 
 class SX127x : public Component,


### PR DESCRIPTION
Just a little change. This makes `on_packet` method a pure virtual function so the `SX127xListener` class becomes abstract class. Without this I've got some vtable errors when defining my class like this:

```cpp
class MyComponent : public sx127x::SX127xListener, public Component {
 public:
  void dump_config() override;
  void loop() override;

  void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override;
```

I've had to change order of inheritance, placing Component as first one, otherwise I've got ```undefined reference to `vtable for esphome::sx127x::SX127xListener'``` errors.

This commit fixes that. It's also how built-in components define their listeners (for example a `VBusListener`).